### PR TITLE
Add mcp-eval skill for evaluating Liferay MCP discoverability

### DIFF
--- a/skills/mcp-eval/SKILL.md
+++ b/skills/mcp-eval/SKILL.md
@@ -1,0 +1,277 @@
+---
+
+allowed-tools: [Agent, AskUserQuestion, Bash, Read, TaskCreate, TaskList, TaskUpdate, Write]
+description: Evaluate Liferay MCP discoverability and usability by attempting a list of user-supplied use cases against a live Liferay instance, failing any case that runs past a three-issue threshold. Produces a per-case verdict (OK / PARTIAL / FAIL), the roadblocks hit (discovery cost, scope ambiguity, missing prerequisites, schema confusion, MCP wrapper bugs, missing endpoints, auth or permission), and a concrete fix for each defect tagged by the surface that owns the change (OpenAPI spec, resource impl, MCP wrapper, external), rendered as a self-contained HTML report. Use when the user asks to evaluate the Liferay MCP, test its discoverability, or report on how well an AI can accomplish typical Liferay operations through it.
+name: mcp-eval
+
+---
+
+# Liferay MCP Evaluation
+
+Drive the Liferay MCP through a list of user-supplied use cases and report how discoverable and usable it is for an AI agent. The output is an evidence-based critique — not a list of "what I did", but a list of what got in the way and why.
+
+## Core Principle: MCP-Only
+
+The point of this evaluation is to prove the MCP, on its own, is enough to accomplish realistic Liferay tasks. The moment work leaks out to any non-MCP channel — `curl`, the Liferay UI, a client JAR, the database, the repo's OpenAPI YAML — the result stops measuring the MCP and starts measuring your ingenuity at routing around it. So the constraint is **hard**, not aspirational: every operation a case needs, from discovery through verification, goes through a `mcp__liferay-mcp__*` tool, retried through the MCP as many times as the task needs, and when the MCP genuinely cannot complete an operation after those retries, **that is the finding** — recorded rather than routed around.
+
+This constraint binds the sub-agent that runs each case, not the orchestrator (which never touches Liferay). The exact out-of-bounds list, the bookkeeping tools that stay allowed, and the one narrow post-FAIL log-reading exception all live in the **Sub-Agent Prompt Template** below.
+
+## Input
+
+The user supplies a list of use cases, clearly split from one another — typically by numbering. Each case is a natural-language description of a Liferay operation. Cases range from simple to complex:
+
+- A simple case fits on one line: "Create a web content article".
+
+- A complex case spans multiple lines, carrying preconditions or several steps.
+
+Treat each item as one case in full, however many lines it occupies — do not assume one line means one case. When the split is ambiguous, ask the user how they intend the list to divide rather than guessing.
+
+When the user asks for an evaluation without providing cases, ask them for the list before proceeding. Do not invent cases.
+
+## Workflow
+
+The evaluation runs through two layers. The **orchestrator** — the agent running this skill — never invokes Liferay MCP tools; it spawns one **sub-agent** per case, collects the per-case JSON object each returns into a running array, and finally renders those objects into a single self-contained HTML report.
+
+Each case runs in its own fresh `general-purpose` sub-agent for the cold-start isolation the evaluation needs: no leaked tool sets, no remembered IDs, no shortcut from "the previous case found this in `c-mcpevalcustomers`". The sub-agents are independent, so the orchestrator spawns them concurrently and collects each per-case JSON object as it returns.
+
+Every rule a sub-agent applies lives inside the **Sub-Agent Prompt Template** below, the single source of truth: the sub-agent sees only that prompt, never this orchestrator-facing half of the file. The orchestrator never scores, classifies, or formats defects itself; to change any sub-agent rule, edit the template.
+
+### Orchestrator Steps
+
+1. **Resolve the output directory.** Outputs must land outside the repository working tree so the working copy stays clean between runs. At the start of every run, call `AskUserQuestion` with the question "Where should I write the evaluation report?" (header "Output path"). Offer these options:
+
+	- `~/Desktop` — visible and easy to find. Recommended.
+	- `~/Documents/mcp-eval` — dedicated folder for repeat runs.
+	- `/tmp/mcp-eval` — ephemeral, cleared on reboot.
+
+	The "Other" choice the prompt always adds lets the user type a custom absolute path. Normalize the chosen value via a single `Bash` call that expands `~`, ensures the directory exists, and prints the absolute path:
+
+	```bash
+	python3 \
+		-c "import os, sys; p = os.path.abspath(os.path.expanduser(sys.argv[1])); os.makedirs(p, exist_ok=True); print(p)" \
+		"<user-input>"
+	```
+
+	The printed line is `<output-dir>` — reuse it as the target for every subsequent `Write` and the render step.
+
+1. **Confirm the input.** When the user has not supplied a list of use cases, ask for one. Do not invent cases.
+
+1. **Create one task per case.** Call `TaskCreate` once for each case at the start so the user has a visible checklist.
+
+1. **Run every case in its own sub-agent.** Mark all case tasks `in_progress` via `TaskUpdate`, then spawn the sub-agents concurrently — issue every `Agent` call (with `subagent_type: general-purpose`) in a single message, passing each the prompt from **Sub-Agent Prompt Template** below with `<<CASE_NUMBER>>` and `<<CASE_TEXT>>` substituted. As each sub-agent returns its single per-case JSON object:
+
+	1. Collect the object into the running array, keyed by case number so the final order matches the user's list. Keep it verbatim; do not reformat, rescore, or reword it. Then enrich the object with a `caseText` field set to the verbatim use-case text from the user's list (the same string substituted for `<<CASE_TEXT>>` in the sub-agent prompt) so the report can show the original input next to the verdict. This is the only orchestrator-side mutation of the per-case object.
+
+	1. Mark that case's task `completed` via `TaskUpdate` with a one-line internal summary (verdict, issues used, tools tried, roadblock tags). This is bookkeeping, not the report.
+
+1. **Render the HTML report.** Assemble the collected per-case JSON objects, in case order, into a single JSON array. Write that array to `<output-dir>/mcp-eval-report.data.json` with the `Write` tool, then splice it into the shipped template and write the final report to `<output-dir>/mcp-eval-report.html`:
+
+	```bash
+	python3 \
+		-c "import pathlib; out = pathlib.Path('<output-dir>'); t = pathlib.Path('<skill-dir>/report-template.html').read_text(); d = (out / 'mcp-eval-report.data.json').read_text(); (out / 'mcp-eval-report.html').write_text(t.replace('__CASE_DATA__', d))"
+	```
+
+	`<skill-dir>` is this skill's base directory, supplied at invocation. `<output-dir>` is the absolute path resolved in Step 1. The template carries all styling and rendering logic and computes the OK/partial/fail tally in its header automatically, so the orchestrator authors no aggregate prose, summary table, or cross-cutting section — it only supplies the data array. Report the absolute path of the written `mcp-eval-report.html` to the user.
+
+### Sub-Agent Prompt Template
+
+The orchestrator passes this prompt to every sub-agent, with `<<CASE_NUMBER>>` replaced by the 1-based index of the case and `<<CASE_TEXT>>` replaced by the verbatim use-case text from the user's list.
+
+```text
+You are running case <<CASE_NUMBER>> of a Liferay MCP evaluation. Your only output is a single JSON object describing the case (schema below) — no Markdown, no code fence, no prose around it. You have no memory of any prior case; assume nothing about the state of the Liferay instance beyond what the live MCP tools tell you.
+
+# Hard Constraint: MCP-Only
+
+Every Liferay operation must go through a `mcp__liferay-mcp__*` tool. Out of bounds even when faster: `curl` against `/o/...` or `/api/...`, the Liferay UI in any browser including Playwright, Java client JARs (`com.liferay.*.rest.client`), `cliferay`, Blade, Gogo shell, direct database access, file-system access under `<bundles>`, log scraping, reading Liferay REST documentation or the OpenAPI YAML in the repo, recalled facts from auto-memory about Liferay endpoints. Discovery must come from `getToolSets`, `getToolSummaries`, and `getTool`. Bookkeeping tools (`Bash` for local `grep`, `Read`, `Write`) are allowed only when they do not touch Liferay.
+
+When the MCP fights back, stay on it: retry through the MCP as many times as the task needs — changing the tool set, scope, or body each time — until the operation either succeeds or you have genuinely exhausted the MCP's avenues. Do not route around the MCP, and do not give up early; recording a step as impossible while an untried MCP path remains is a reporting error, not a finding. Only when the MCP truly cannot complete an operation is that the finding — record it and move on.
+
+This constraint governs the attempt only. The one exception is post-mortem log reading: see `Post-FAIL Diagnosis` below.
+
+# Issue Threshold: Three
+
+Three issues is a flag, not a stop sign. Work the case through every step it legitimately needs and record each defect as it surfaces. An issue is any moment the MCP fails to behave the way its own surface advertised: a POST rejected for a missing field the schema never marked `required`, a tool set whose name promised a scope it then refuses, a "success" response that produced no entity, a wrapper error on a call that should have succeeded. Each issue is also a defect to record. Steps that behave as documented cost nothing, and discovery (`getToolSets`, `getToolSummaries`, `getTool`) never counts as an issue on its own.
+
+Keep going past the third issue. Finding the fourth, fifth, or sixth defect in the same case is exactly what tells the reader how broken a surface is, and stopping early hides that signal. The threshold is a quality bar, not a budget: once `issuesUsed > 3` the case is a **FAIL** no matter how many steps you go on to complete, because a surface that costs four or more issues to drive has failed the usability test even when the work technically goes through. At three issues or fewer, the verdict rolls up from what actually happened (see **Scoring**).
+
+Stop only when no remaining step has anything left to attempt — every dependency is missing, or the case has run to its natural end. That is a verdict, not a budget cutoff.
+
+# Steps And Conditions
+
+Your case may bundle several steps or named conditions — a complex case especially. Do not collapse them prematurely. Evaluate each step or condition on its own: invoke it, observe the result, and note whether it held. An issue attaches to the specific step that misbehaved, not to the case as a whole.
+
+The case carries a single verdict, the rollup of its steps, defined under **Scoring** below. When the case has more than one step or condition, give each step its own entry in the `flow` array (format below) so the reader sees which part held and which broke instead of one opaque verdict. A step that could not be attempted because of an unresolvable dependency is a `flow` entry with `outcome: "blocked"`; a step that surfaced an MCP defect is `outcome: "issue"`.
+
+# Prerequisite Handling
+
+Many cases need entities that must already exist — a site, a role, a content structure, a workflow definition. How you treat the prerequisite depends on where it comes from:
+
+- **Part of the natural workflow, and the MCP exposes the setup path.** Do it through the MCP. "Create a custom object entry" naturally entails *define → publish → insert*; that is one case, not three, and none of those steps counts as an issue as long as each behaves as documented.
+
+- **Environmental** — a workflow engine, an SMTP relay, a feature flag, anything the MCP cannot reasonably bootstrap. Tag the affected step `missing-prerequisite` and continue with any other steps that do not depend on it; the case fails only when nothing else can proceed.
+
+Also tag `missing-prerequisite` when the requirement only surfaces mid-case, and treat each as an issue because the surface did not behave as advertised:
+
+- The `getTool` schema named a `required` field (`contentStructureId`, `workflowDefinitionId`, `accountId`, `objectDefinitionId`) that resolves to nothing in the instance.
+- An error response named an entity that does not exist.
+- A "successful" response left the entity in a non-functional state (status `draft`, `inactive`, `pending`), needing a follow-up activation step the schema never mentioned.
+
+Late discovery is the most expensive kind: the user already invested steps before learning the prerequisite even applied. Record that the discovery was late, not just that the prerequisite was missing.
+
+# Discovery Loop
+
+1. `getToolSets` to find a candidate tool set.
+1. `getToolSummaries` to find a candidate tool.
+1. `getTool` to fetch the input schema.
+1. `invokeTool` to execute. When the first candidate is wrong, that is itself a finding — log it, then try the next one.
+
+# Scoring
+
+Pick one verdict for the case. First apply the threshold gate: when `issuesUsed > 3`, the verdict is **FAIL** regardless of how many steps succeeded. Otherwise — three issues or fewer — roll the steps up: **OK** only when every required step succeeded, **PARTIAL** when at least one succeeded and at least one did not, **FAIL** when no required step produced a recognisable success.
+
+- **OK** — three issues or fewer, every required step completed, and the response confirms it: an entity ID, a `status: "Approved"` field, a 200 or 201 payload.
+- **OK (with wrapper bug)** — three issues or fewer; the underlying REST calls succeeded (real IDs or success payloads came back) but the MCP wrapper returned errors on one or more of them.
+- **PARTIAL** — three issues or fewer; at least one required step succeeded and at least one did not (e.g. created a draft but could not publish; the read-only variant succeeded while the write variant did not).
+- **FAIL** — `issuesUsed > 3`, or no required step produced a recognisable success.
+
+Below the threshold a case can finish OK with up to three issues (surface complaints, but every step ultimately worked) or FAIL with one (the single issue blocked everything else). Above it the count alone forces FAIL — but when you nonetheless drove every required step to success through the MCP, record that in `achievable` (see **Required Output**) so the reader sees the operation is possible, just too costly.
+
+# Post-FAIL Diagnosis
+
+After the case has run to its end and the verdict has settled at **FAIL**, you may read the bundle logs at `<bundles>/logs/liferay.<yyyy-MM-dd>.log` to diagnose why the attempt failed and sharpen your defect bullets with a concrete root cause. This is the sole exception to the MCP-only constraint, and it is narrow: log reading only (no database, no other file-system access), available only once the verdict is **FAIL**, and never used to retroactively complete the case or change the score. If the verdict is not FAIL, do not read the logs.
+
+# Roadblock Taxonomy
+
+Tag every defect with one or more of these. A defect can carry several tags — record all that apply. When something fits none of them, invent a new tag and flag it explicitly so future runs consider it.
+
+- **discovery-cost** — finding the right tool set or tool consumed disproportionate effort: empty descriptions on tool sets, oversized `getToolSummaries` payloads, names that do not hint at scope.
+- **scope-ambiguity** — multiple tool sets appear to fit the same operation but target different scopes (site vs. asset library vs. depot vs. company), and the names do not disambiguate.
+- **missing-prerequisite** — the call shape is right but the instance lacks required seed data (Content Structures, Forms, Object Definitions, workflow definitions, etc.).
+- **dynamic-toolset** — a tool set the operation needs only exists after a separate publishing or activation step, and is not visible in the initial `getToolSets` call.
+- **schema-confusion** — the input schema is technically valid but practically misleading: a `required` field with no documented default, enum values that are not enumerated, or a `body` shape that nests differently from comparable tools.
+- **mcp-wrapper-bug** — the underlying REST call likely succeeded but the MCP layer returned an error (e.g. `-32603 "text must not be null"` on a 204 No Content response).
+- **missing-endpoint** — the operation a user would expect (e.g. "create a Form definition") is not exposed by any MCP tool set, even though it exists in the product.
+- **auth-or-permission** — the call failed with a 401/403 or an "operation not permitted" message under the MCP server's effective identity.
+
+# Required Output
+
+Return exactly one JSON object and nothing else: no Markdown, no code fence, no preamble or postscript. It must parse with a single `JSON.parse`. The object has this shape (the orchestrator adds a `caseText` field afterwards with the verbatim use-case text; do not include it yourself):
+
+```json
+
+{
+  "caseNumber": <<CASE_NUMBER>>,
+  "title": "<Use Case in Title Case>",
+  "verdict": "OK" | "OK (with wrapper bug)" | "PARTIAL" | "FAIL",
+  "issuesUsed": <integer; may exceed issuesMax>,
+  "issuesMax": 3,
+  "flow": [
+    {
+      "tool": "<toolSet/toolName>" | null,
+      "intent": "<what the agent tried at this step>",
+      "result": "<what happened>",
+      "outcome": "ok" | "issue" | "blocked" | "note",
+      "request": <JSON arguments passed to invokeTool, optional>,
+      "response": <JSON body returned by the tool, optional>,
+      "defect": {
+        "tag": "<roadblock-taxonomy tag>",
+        "description": "<why it is a defect, concrete enough to file as a ticket>",
+        "alternatives": [
+          {"title": "<fix title>", "surface": "openapi", "detail": "<one or two sentences>", "diff": "<unified diff, optional>"}
+        ],
+        "additional": [
+          {"title": "<complementary fix title>", "surface": "resource-impl", "detail": "<one or two sentences>", "diff": "<unified diff, optional>"}
+        ]
+      }
+    }
+  ],
+  "happyPathNote": "<one-line keeper>" | null,
+  "achievable": "<one-line note that the case completed end-to-end through the MCP despite the issues>" | null
+}
+
+```
+
+Field rules:
+
+- **title** — the use case in Title Case, not the verbatim input.
+- **verdict** — one of the four strings exactly; the renderer keys its color off the `OK` / `PARTIAL` / `FAIL` prefix.
+- **flow** — the unified timeline of MCP interactions, from discovery through the verdict. Each entry is an object with the following fields:
+	- `tool` — the `toolSet/toolName` invoked (string), or `null` for an entry that is not a tool call (a planning decision, a high-level "blocked" summary of unreached scope, the post-FAIL log read).
+	- `intent` — what the agent tried to accomplish at this step, written as a short imperative or noun phrase. Inline markup applies.
+	- `result` — one or two sentences on what actually happened. Inline markup applies. Reference other tools or fields inline with backticks.
+	- `outcome` — one of `ok` (the action behaved as documented), `issue` (an MCP defect surfaced — this entry counts toward `issuesUsed` and must carry a `defect` object, described below), `blocked` (the agent could not attempt this part because of a prior issue), `note` (a planning step, a decision, or an observation that does not pass or fail).
+	- `request` — the **complete, exact** arguments object passed to `invokeTool` for this step, reproduced field for field. This must be the literal payload that produced the `response` recorded beside it, so that a reader can copy the request, replay the call, and reproduce the same outcome. Build this field by capturing the arguments at the moment of the call, not by reconstructing them from memory afterward. Include every field the call actually sent: the full request body, every nested object, all path parameters, and the body-nesting wrapper if one was used. Never abbreviate, summarize, omit a field, or collapse a body to a representative subset, because a partial request silently misattributes the failure (a body missing a required attachment reads as an unimplemented endpoint when the real cause was the missing field). Unlike `response`, the `request` is never truncated, with one narrow exception: a single very long opaque value such as a base64 attachment blob may be shortened to a clearly marked placeholder (for example `"<base64, 1024 chars>"`) as long as the field itself and every sibling field remain present. Omit the whole field only when `tool` is `null` or the call genuinely sends no arguments. The renderer pretty-prints it inside a collapsed **Request** section under the flow entry so a reader can replay the call.
+	- `response` — the JSON body returned by the tool, captured verbatim as a JSON object. Omit when `tool` is `null`. For a response whose payload is large (a page of hundreds of items, an export blob), keep the top-level structure but truncate arrays with a `"...truncated (N items)..."` placeholder so the report stays scannable; never paraphrase the error or schema information, which is exactly what the reader needs to see. The renderer pretty-prints it inside a collapsed **Response** section under the flow entry.
+	- `defect` — present only on `outcome: "issue"` entries; absent everywhere else. Describes the MCP defect this step surfaced and the fix(es). Be specific about *why* it is a defect, never just that something failed: say what about the response was the actual problem (not "got a 400" but "the error named no valid scope, so the user must guess which scopes the tool set accepts"). The renderer pretty-prints it inside a collapsed **Defect** section under Request and Response. Fields:
+		- `tag` — one tag from the roadblock taxonomy above.
+		- `description` — one or two sentences explaining the defect.
+		- `alternatives` — array of solution objects (described under **Solutions** below), mutually exclusive; every defect needs at least one entry. One entry renders as "Fix"; more than one renders as "Alternative fixes — pick one".
+		- `additional` — array of complementary solution objects that apply alongside the chosen alternative. Renders as "Also apply — alongside the fix above". Leave as `[]` when there are none.
+
+	**One flow entry per MCP call.** A `getToolSets` to find a candidate, a `getToolSummaries` to drill down, a `getTool` to fetch the schema, and an `invokeTool` to execute land as four separate entries — the value of the report is in watching the MCP get navigated step by step, not in a summary of the navigation. Keep each `result` short (usually one sentence) so a long case stays scannable. A retry with a different tool, a fall-back to a read to isolate the layer, a give-up decision after the budget is spent — each gets its own entry. The number of `outcome: "issue"` entries must equal `issuesUsed`.
+
+	A discovery call has `outcome: "note"`; the `result` says what the call returned that pushed the next step:
+
+	```json
+	{
+	  "tool": "getToolSets",
+	  "intent": "Find a tool set that exposes **object definition** create operations",
+	  "result": "Returned **47 tool sets**; `object-admin-v1.0` is the only candidate whose name mentions objects.",
+	  "outcome": "note",
+	  "response": {"toolSets": ["...truncated (47 items)..."]}
+	}
+
+	```
+
+	An `invokeTool` call has one of `ok`, `issue`, or `blocked`. An `issue` example, with its `defect` attached:
+
+	```json
+	{
+	  "tool": "object-admin-v1.0/postObjectDefinition",
+	  "intent": "Create the **Conference** object definition with a schema-valid body",
+	  "result": "**HTTP 415 Unsupported Media Type** before any field validation.",
+	  "outcome": "issue",
+	  "request": {"name": "Conference", "label": {"en_US": "Conference"}, "objectFields": [{"name": "name", "businessType": "Text", "required": true}]},
+	  "response": {"status": 415, "title": "Unsupported Media Type"},
+	  "defect": {
+	    "tag": "mcp-wrapper-bug",
+	    "description": "The wrapper rejected the call with **415** before forwarding to the resource, even though the schema documents `application/json` as the only accepted media type. The caller has no way to override Content-Type, so the surface contradicts the schema.",
+	    "alternatives": [
+	      {"title": "Inject `Content-Type: application/json` in `invokeTool`", "surface": "mcp-wrapper", "detail": "The wrapper should set Content-Type from the OpenAPI operation's request body content type instead of leaving it unset."}
+	    ],
+	    "additional": []
+	  }
+	}
+
+	```
+
+- **happyPathNote** — for a clean success, one short observation worth keeping (e.g. that a friendly key worked, or that pagination mapped cleanly). Set it to `null` whenever any flow entry carries a `defect`.
+- **achievable** — the counterpart to `happyPathNote` for a threshold **FAIL**: when `issuesUsed > 3` but you still drove every required step to success through the MCP, set this to one explicit sentence saying so (e.g. **Completed end-to-end through the MCP after 5 issues** — the operation is possible, just costly). Set it to `null` whenever any required step remained incomplete, so a `null` here means the case truly could not be finished through the MCP.
+- **Inline emphasis** — the `intent`, `result`, `description`, `detail`, `happyPathNote`, and `achievable` text render lightweight inline markup: wrap a phrase in `**double asterisks**` for bold and in `` `backticks` `` for code. Bold the one phrase that carries the point — the actual problem, the verdict-driving outcome — so the reader is not parsing a wall of even-weight prose. Do not bold whole sentences, and keep each text field to one or two crisp sentences rather than a paragraph.
+
+**Solutions.** Each entry in `defect.alternatives` and `defect.additional` is an object with `title`, `surface`, `detail`, and an optional `diff`. The `surface` selects where the fix lives, and the renderer color-codes it:
+
+- **`openapi`** — fix lives in a `rest-openapi.yaml` or its annotations / `EntityModel`. Prefer this whenever the spec can express the fix; most defects translate into spec edits that ripple through `getToolSets`, `getToolSummaries`, and `getTool` for free.
+- **`resource-impl`** — fix lives in a `*ResourceImpl` Java class.
+- **`mcp-wrapper`** — fix lives in `mcp-server` or `mcp-server-rest-impl`.
+- **`external`** — fix lives outside Liferay.
+
+`detail` states the concrete change in one or two sentences. `diff` is optional but encouraged when the fix is a small, nameable patch: a real unified diff (`--- a/...`, `+++ b/...`, `@@`, `+`/`-` lines) that the renderer syntax-highlights. Omit `diff` entirely when the change is too diffuse to patch in a few lines.
+
+Anti-patterns in `description` and `detail`:
+
+- "The tool was hard to find." Say *why*: "Tool set `X` has an empty description and a misleading name (`cms-*` implies CMS-wide reach but only accepts asset library scopes)."
+- "Got a 400." Say *what about the response was the actual problem*: "The error `Group ID 20127 is not valid for scope 'depot'` did not indicate which scopes the tool set accepts; the user has to infer it from the error."
+- "The case is complex." Say *which step* is the friction: "The case completes in three calls, but step 2 (`publish`) is undocumented — nothing in step 1's response mentions it is required."
+
+# Conduct
+
+- The report is about what got in the way, not a transcript. The `flow` field carries the timeline as one entry per MCP call (see **One flow entry per MCP call** above); each `outcome: "issue"` entry carries its own `defect` with the why and the fix(es); `happyPathNote` captures keepers from clean runs. Keep each entry's `result` short rather than narrating internal deliberation, and do not restate the `intent` or `result` text inside `defect.description` — the defect should add what the entry does not already say.
+- Retry through the MCP as many times as the task needs, but never retry a tool with the *same* input hoping for a different result. Each retry must change something — a different tool set, scope key, or body shape — and the change is itself a finding. Exhaust these MCP avenues before recording a step as impossible; giving up while an untried MCP path remains is a reporting error, not a finding.
+- Capture the `request` for a call the moment you invoke the tool, and record the complete arguments exactly as sent (see the `request` field rules above). A flow entry whose `request` is missing fields is worse than one with no `request` at all, because it points the reader at the wrong root cause: a write that failed for a missing required field reads as a broken endpoint when the body was simply incomplete. When in doubt about whether a failure was the surface or the payload, replay the call with a complete, valid body before settling the `defect`.
+- Do not read prior memory entries about Liferay endpoints. The evaluation must reflect cold-start discoverability.
+
+# Case to Evaluate
+
+<<CASE_TEXT>>
+```

--- a/skills/mcp-eval/report-template.html
+++ b/skills/mcp-eval/report-template.html
@@ -1,0 +1,475 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta content="width=device-width, initial-scale=1" name="viewport" />
+<title>Liferay MCP Evaluation Report</title>
+<style>
+:root {
+	--ok: #2e7d32; --ok-bg: #e8f5e9;
+	--partial: #ef6c00; --partial-bg: #fff3e0;
+	--fail: #c62828; --fail-bg: #ffebee;
+	--ink: #1a1a1a; --muted: #5f6b7a; --line: #e3e8ef;
+	--card-bg: #ffffff; --page-bg: #f4f6f9;
+	--openapi: #1565c0; --resource-impl: #00838f; --mcp-wrapper: #6a1b9a; --external: #546e7a;
+}
+* { box-sizing: border-box; }
+body {
+	margin: 0; background: var(--page-bg); color: var(--ink);
+	font: 17px/1.62 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+header.top { background: #0b1f33; color: #fff; padding: 30px 56px; }
+header.top h1 { margin: 0 0 6px; font-size: 28px; font-weight: 650; }
+header.top .meta { color: #9fb3c8; font-size: 15px; }
+header.top .tally { margin-left: 6px; }
+header.top .tally b { color: #fff; }
+main { max-width: 1280px; margin: 0 auto; padding: 30px 32px 96px; }
+
+/* Inline emphasis shared across body text */
+.case-body strong, .happy strong { font-weight: 700; color: var(--ink); }
+.case-body code, .happy code {
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: .9em;
+	background: #eef2f7; color: #33425b; padding: 1px 6px; border-radius: 5px;
+}
+
+.case { background: var(--card-bg); border: 1px solid var(--line); border-left: 6px solid #999;
+		  border-radius: 12px; margin-bottom: 14px; overflow: hidden; }
+.case.ok { border-left-color: var(--ok); }
+.case.partial { border-left-color: var(--partial); }
+.case.fail { border-left-color: var(--fail); }
+.case-head { display: flex; align-items: center; gap: 16px; padding: 18px 24px; cursor: pointer; }
+.case-head:hover { background: #fafbfd; }
+.case-num { font-variant-numeric: tabular-nums; color: var(--muted); font-size: 15px; font-weight: 600; }
+.case-title { font-weight: 600; flex: 1; font-size: 18px; }
+.badge { font-size: 13px; font-weight: 700; letter-spacing: .03em; padding: 5px 13px; border-radius: 999px; white-space: nowrap; }
+.badge.ok { background: var(--ok-bg); color: var(--ok); }
+.badge.partial { background: var(--partial-bg); color: var(--partial); }
+.badge.fail { background: var(--fail-bg); color: var(--fail); }
+.issues { font-size: 14px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.issues.exceeded { color: var(--fail); font-weight: 600; }
+.chev { color: var(--muted); transition: transform .15s; display: inline-block; }
+.collapsed > .case-head .chev,
+.collapsed > .solution-head .chev { transform: rotate(-90deg); }
+.case.collapsed .case-body { display: none; }
+.case-body { padding: 8px 24px 22px; border-top: 1px solid var(--line); }
+
+.field { margin-top: 20px; }
+.field h3 { margin: 0 0 9px; font-size: 12.5px; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); }
+/* Collapsible Steps / Defects sections */
+.field.collapsible > h3 { cursor: pointer; user-select: none; display: flex; align-items: center; gap: 8px; }
+.field.collapsible > h3 .chev { font-size: 11px; }
+.field.collapsed > h3 .chev { transform: rotate(-90deg); }
+.field.collapsed > .field-body { display: none; }
+/* Flow — the unified timeline of MCP interactions, results, issues, and agent responses */
+.flow { list-style: none; margin: 0; padding: 0; }
+.flow-entry { position: relative; padding: 0 0 18px 44px; }
+.flow-entry:last-child { padding-bottom: 2px; }
+.flow-marker {
+	position: absolute; left: 0; top: 1px;
+	width: 28px; height: 28px; border-radius: 50%;
+	display: flex; align-items: center; justify-content: center;
+	font-size: 13px; font-weight: 700;
+	font-variant-numeric: tabular-nums;
+}
+.flow-entry:not(:last-child)::after {
+	content: ""; position: absolute; left: 13px; top: 30px; bottom: -1px; width: 2px;
+	background: var(--line);
+}
+.flow-entry.ok .flow-marker { background: var(--ok-bg); color: var(--ok); }
+.flow-entry.issue .flow-marker { background: var(--fail-bg); color: var(--fail); }
+.flow-entry.blocked .flow-marker { background: #eef2f7; color: var(--muted); }
+.flow-entry.note .flow-marker { background: #eef2f7; color: var(--muted); }
+.flow-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 4px; }
+.flow-tool {
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13.5px; font-weight: 600;
+	padding: 3px 9px; border-radius: 5px;
+}
+.flow-tool-discovery-sets { background: #f3e8ff; color: #6b21a8; }
+.flow-tool-discovery-summaries { background: #fef3c7; color: #92400e; }
+.flow-tool-discovery-schema { background: #d1fae5; color: #065f46; }
+.flow-tool-invocation { background: #e4ecf7; color: #1d4e6f; }
+.flow-pill {
+	font-size: 12px; font-weight: 700; letter-spacing: .03em;
+	padding: 2px 9px; border-radius: 999px;
+}
+.flow-pill.issue { background: var(--fail-bg); color: var(--fail); }
+.flow-pill.blocked { background: #eef2f7; color: var(--muted); }
+.flow-intent { font-weight: 600; font-size: 16px; line-height: 1.5; }
+.flow-result { color: #4a5566; font-size: 15.5px; line-height: 1.55; margin-top: 2px; }
+.flow code, .flow-intent code, .flow-result code {
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 14px; font-weight: 600;
+	background: #eef2f7; color: #33425b; padding: 1px 6px; border-radius: 5px;
+}
+
+/* Per-step request/response payloads — native <details>, collapsed by default */
+.flow-payloads { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.flow-payload {
+	border: 1px solid var(--line); border-radius: 6px;
+	overflow: hidden; background: #fcfdff;
+}
+.flow-payload summary {
+	cursor: pointer; padding: 5px 11px;
+	background: #f5f7fb; color: var(--muted);
+	font-weight: 700; letter-spacing: .04em; text-transform: uppercase;
+	font-size: 11px; list-style: none; user-select: none;
+}
+.flow-payload summary::-webkit-details-marker { display: none; }
+.flow-payload summary::before {
+	content: "▸"; display: inline-block; margin-right: 6px;
+	font-size: 10px; transition: transform .15s;
+}
+.flow-payload[open] summary::before { transform: rotate(90deg); }
+.flow-payload[open] summary { border-bottom: 1px solid var(--line); }
+.flow-payload pre {
+	margin: 0; padding: 10px 12px;
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+	font-size: 12.5px; line-height: 1.55;
+	background: #fafbfd; overflow-x: auto;
+	max-height: 360px; overflow-y: auto;
+	white-space: pre;
+}
+.flow-payload .json-key { color: #d73a49; }
+.flow-payload .json-string { color: #032f62; }
+.flow-payload .json-number { color: #005cc5; }
+.flow-payload .json-boolean { color: #6f42c1; }
+.flow-payload .json-null { color: #6a737d; font-style: italic; }
+
+/* Defect payload — same shell as request/response, but with a typography-rich body */
+.flow-payload-defect summary { background: #fff4f3; color: var(--fail); }
+.flow-payload-defect[open] summary { border-bottom-color: #f5c6c0; }
+.flow-payload-defect summary .defect-tag {
+	display: inline-block; margin-left: 4px;
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+	font-size: 11px; font-weight: 700; letter-spacing: .02em;
+	padding: 1px 7px; border-radius: 4px;
+	background: #fff; color: var(--fail);
+	text-transform: none;
+}
+.flow-payload-defect .defect-body { padding: 13px 15px 15px; background: #fff; }
+.flow-payload-defect .defect-desc { font-size: 15.5px; line-height: 1.6; color: var(--ink); }
+.flow-payload-defect .defect-desc strong { font-weight: 700; }
+.flow-payload-defect .defect-desc code {
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: .9em;
+	background: #eef2f7; color: #33425b; padding: 1px 6px; border-radius: 5px;
+}
+
+/* Solution groups — alternatives vs complementary */
+.sol-group { margin-top: 18px; }
+.sol-group-label { display: flex; align-items: baseline; gap: 8px; margin: 0 0 9px; padding-left: 2px; }
+.sol-group-label .name { font-size: 13px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--ink); }
+.sol-group-label .hint { font-size: 13px; color: var(--muted); }
+.solutions { display: flex; flex-direction: column; gap: 10px; }
+
+/* Solution — each its own collapsible section */
+.solution { border: 1px solid var(--line); border-radius: 9px; overflow: hidden; background: #fff; }
+.solution-head { display: flex; align-items: center; gap: 12px; padding: 13px 15px; cursor: pointer; }
+.solution-head:hover { background: #f7f9fc; }
+.solution-title { flex: 1; font-weight: 600; font-size: 16px; }
+.surface { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12.5px; font-weight: 600;
+			 padding: 3px 9px; border-radius: 5px; color: var(--muted); background: #eef2f7; white-space: nowrap; }
+.surface.openapi { color: var(--openapi); }
+.surface.resource-impl { color: var(--resource-impl); }
+.surface.mcp-wrapper { color: var(--mcp-wrapper); }
+.surface.external { color: var(--external); }
+.solution.collapsed .solution-body { display: none; }
+.solution-body { padding: 0 15px 15px; border-top: 1px solid var(--line); }
+.solution-body .detail { margin: 12px 0; font-size: 16px; }
+
+.diff { margin: 0; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13.5px;
+		  line-height: 1.55; border: 1px solid var(--line); border-radius: 6px; overflow-x: auto; white-space: pre; }
+.diff span { display: block; padding: 0 12px; }
+.diff .meta { color: #6a737d; background: #f6f8fa; }
+.diff .hunk { color: #005cc5; background: #f1f8ff; }
+.diff .add { color: #22863a; background: #e6ffed; }
+.diff .del { color: #b31d28; background: #ffeef0; }
+.diff .ctx { color: #24292e; }
+
+.happy { margin-top: 18px; padding: 13px 16px; background: var(--ok-bg); color: #1b5e20; border-radius: 8px; font-size: 16px; }
+
+/* Achievable — case crossed the fail threshold but still completed through the MCP */
+.achievable { margin-top: 18px; padding: 13px 16px; background: var(--partial-bg); color: #8a4b00;
+				 border-left: 4px solid var(--partial); border-radius: 8px; font-size: 16px; }
+.achievable strong { font-weight: 700; }
+.achievable code {
+	font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: .9em;
+	background: #fff; color: #8a4b00; padding: 1px 6px; border-radius: 5px;
+}
+
+/* Use Case — verbatim user-supplied prompt, collapsed by default */
+.case-text {
+	white-space: pre-wrap; word-wrap: break-word;
+	font-size: 15px; line-height: 1.6; color: var(--ink);
+	background: #f7f9fc; border: 1px solid var(--line); border-radius: 8px;
+	padding: 14px 16px; max-height: 480px; overflow-y: auto;
+}
+</style>
+</head>
+
+<body>
+<header class="top">
+<h1>Liferay MCP Evaluation Report</h1>
+<div class="meta" id="report-meta"></div>
+</header>
+
+<main>
+<section id="cases"></section>
+</main>
+
+<script id="case-data" type="application/json">
+__CASE_DATA__
+</script>
+
+<script>
+(function () {
+const cases = JSON.parse(document.getElementById("case-data").textContent);
+
+function esc(s) {
+	return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function baseVerdict(v) {
+	if (v.startsWith("OK")) return "ok";
+	if (v === "PARTIAL") return "partial";
+	return "fail";
+}
+// Escape, then apply lightweight inline markup: **bold** and `code`.
+function fmt(s) {
+	return esc(s)
+	  .replace(/`([^`]+)`/g, "<code>$1</code>")
+	  .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+}
+// A collapsible "field" section (used for Steps and Defects).
+function makeField(title, collapsible, startCollapsed) {
+	const f = document.createElement("div");
+	f.className = "field" + (collapsible ? " collapsible" : "") + (startCollapsed ? " collapsed" : "");
+	const h = document.createElement("h3");
+	if (collapsible) {
+	  h.innerHTML = `<span class="chev">▾</span>${esc(title)}`;
+	  h.addEventListener("click", () => f.classList.toggle("collapsed"));
+	} else {
+	  h.textContent = title;
+	}
+	const body = document.createElement("div");
+	body.className = "field-body";
+	f.appendChild(h);
+	f.appendChild(body);
+	return { field: f, body };
+}
+
+const tally = { ok: 0, partial: 0, fail: 0 };
+cases.forEach(c => tally[baseVerdict(c.verdict)]++);
+document.getElementById("report-meta").innerHTML =
+	cases.length + " use cases · generated " + new Date().toLocaleString() +
+	`<span class="tally"> · <b>${tally.ok}</b> OK · <b>${tally.partial}</b> partial · <b>${tally.fail}</b> fail</span>`;
+
+function renderDiff(diff) {
+	return diff.split("\n").map(line => {
+	  let cls = "ctx";
+	  if (line.startsWith("+++") || line.startsWith("---")) cls = "meta";
+	  else if (line.startsWith("@@")) cls = "hunk";
+	  else if (line.startsWith("+")) cls = "add";
+	  else if (line.startsWith("-")) cls = "del";
+	  return `<span class="${cls}">${esc(line) || "&nbsp;"}</span>`;
+	}).join("");
+}
+
+function renderSolution(s) {
+	const detail = s.detail ? `<p class="detail">${fmt(s.detail)}</p>` : "";
+	const diff = s.diff ? `<pre class="diff">${renderDiff(s.diff)}</pre>` : "";
+	const el = document.createElement("div");
+	el.className = "solution collapsed";
+	el.innerHTML =
+	  `<div class="solution-head">
+		 <span class="chev">▾</span>
+		 <span class="solution-title">${esc(s.title)}</span>
+		 <span class="surface ${esc(s.surface)}">${esc(s.surface)}</span>
+	   </div>
+	   <div class="solution-body">${detail}${diff}</div>`;
+	el.querySelector(".solution-head").addEventListener("click", () => el.classList.toggle("collapsed"));
+	return el;
+}
+
+function renderGroup(name, hint, solutions) {
+	const g = document.createElement("div");
+	g.className = "sol-group";
+	g.innerHTML = `<div class="sol-group-label"><span class="name">${esc(name)}</span>` +
+				  (hint ? `<span class="hint">${esc(hint)}</span>` : "") + `</div>`;
+	const wrap = document.createElement("div");
+	wrap.className = "solutions";
+	solutions.forEach(s => wrap.appendChild(renderSolution(s)));
+	g.appendChild(wrap);
+	return g;
+}
+
+function renderDefectPayload(d) {
+	const wrap = document.createElement("details");
+	wrap.className = "flow-payload flow-payload-defect";
+
+	const summary = document.createElement("summary");
+	summary.innerHTML = `Defect <span class="defect-tag">${esc(d.tag)}</span>`;
+	wrap.appendChild(summary);
+
+	const body = document.createElement("div");
+	body.className = "defect-body";
+	body.innerHTML = `<div class="defect-desc">${fmt(d.description)}</div>`;
+
+	const alts = d.alternatives || [];
+	const adds = d.additional || [];
+	if (alts.length > 1) body.appendChild(renderGroup("Alternative fixes", "pick one", alts));
+	else if (alts.length === 1) body.appendChild(renderGroup("Fix", "", alts));
+	if (adds.length) body.appendChild(renderGroup("Also apply", "alongside the fix above", adds));
+
+	wrap.appendChild(body);
+	return wrap;
+}
+
+// Classify the `tool` field so the flow-tool pill picks a color per category.
+function toolClass(name) {
+	if (name === "getToolSets") return "flow-tool-discovery-sets";
+	if (name === "getToolSummaries") return "flow-tool-discovery-summaries";
+	if (name === "getTool") return "flow-tool-discovery-schema";
+	return "flow-tool-invocation";
+}
+
+// Lightweight JSON syntax highlighter — runs on the HTML-escaped string.
+function highlightJSON(escapedJson) {
+	return escapedJson.replace(
+	  /("(?:\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+\-]?\d+)?)/g,
+	  (match, stringTok, colonTok, keywordTok, numberTok) => {
+		if (stringTok !== undefined) {
+		  const cls = colonTok ? "json-key" : "json-string";
+		  return `<span class="${cls}">${stringTok}</span>${colonTok || ""}`;
+		}
+		if (keywordTok !== undefined) {
+		  const cls = keywordTok === "null" ? "json-null" : "json-boolean";
+		  return `<span class="${cls}">${keywordTok}</span>`;
+		}
+		return `<span class="json-number">${numberTok}</span>`;
+	  }
+	);
+}
+
+function renderPayload(label, content) {
+	let formatted;
+	let isJSON = true;
+	if (typeof content === "string") {
+	  try {
+		formatted = JSON.stringify(JSON.parse(content), null, 2);
+	  } catch (e) {
+		formatted = content;
+		isJSON = false;
+	  }
+	} else {
+	  formatted = JSON.stringify(content, null, 2);
+	}
+	const escaped = esc(formatted);
+	const body = isJSON ? highlightJSON(escaped) : escaped;
+	return `<details class="flow-payload"><summary>${esc(label)}</summary><pre>${body}</pre></details>`;
+}
+
+function renderFlowEntry(entry, issueIndex) {
+	const outcome = entry.outcome || "note";
+	let marker;
+	if (outcome === "ok") marker = "✓";
+	else if (outcome === "issue") marker = String(issueIndex);
+	else if (outcome === "blocked") marker = "−";
+	else marker = "•";
+
+	const pieces = [];
+	if (entry.tool) pieces.push(`<span class="flow-tool ${toolClass(entry.tool)}">${esc(entry.tool)}</span>`);
+	if (outcome === "issue") pieces.push(`<span class="flow-pill issue">Issue ${issueIndex}</span>`);
+	else if (outcome === "blocked") pieces.push(`<span class="flow-pill blocked">Blocked</span>`);
+
+	const head = pieces.length ? `<div class="flow-head">${pieces.join("")}</div>` : "";
+	const intent = entry.intent ? `<div class="flow-intent">${fmt(entry.intent)}</div>` : "";
+	const result = entry.result ? `<div class="flow-result">${fmt(entry.result)}</div>` : "";
+
+	const li = document.createElement("li");
+	li.className = "flow-entry " + outcome;
+	li.innerHTML = `<div class="flow-marker">${marker}</div>${head}${intent}${result}`;
+
+	// Payloads — Request, Response, Defect (each its own collapsed details block).
+	const hasRequest = entry.request !== undefined && entry.request !== null;
+	const hasResponse = entry.response !== undefined && entry.response !== null;
+	const hasDefect = !!entry.defect;
+	if (hasRequest || hasResponse || hasDefect) {
+	  const wrap = document.createElement("div");
+	  wrap.className = "flow-payloads";
+	  if (hasRequest) wrap.insertAdjacentHTML("beforeend", renderPayload("Request", entry.request));
+	  if (hasResponse) wrap.insertAdjacentHTML("beforeend", renderPayload("Response", entry.response));
+	  if (hasDefect) wrap.appendChild(renderDefectPayload(entry.defect));
+	  li.appendChild(wrap);
+	}
+
+	return li;
+}
+
+function renderCase(c) {
+	const bv = baseVerdict(c.verdict);
+
+	const el = document.createElement("div");
+	el.className = "case " + bv + " collapsed";
+	const overThreshold = c.issuesUsed > c.issuesMax;
+	const issuesText = overThreshold
+	  ? `${c.issuesUsed}/${c.issuesMax} issues · over threshold`
+	  : `${c.issuesUsed}/${c.issuesMax} issues`;
+	const issuesClass = overThreshold ? "issues exceeded" : "issues";
+	el.innerHTML =
+	  `<div class="case-head">
+		 <span class="chev">▾</span>
+		 <span class="case-num">#${c.caseNumber}</span>
+		 <span class="case-title">${esc(c.title)}</span>
+		 <span class="${issuesClass}">${issuesText}</span>
+		 <span class="badge ${bv}">${esc(c.verdict)}</span>
+	   </div>
+	   <div class="case-body"></div>`;
+	const cbody = el.querySelector(".case-body");
+
+	// Use Case — verbatim user-supplied prompt, collapsible and collapsed by default.
+	if (c.caseText) {
+	  const caseTextField = makeField("Use Case", true, true);
+	  caseTextField.body.innerHTML = `<div class="case-text">${esc(c.caseText)}</div>`;
+	  cbody.appendChild(caseTextField.field);
+	}
+
+	// Flow — unified timeline of tools, results, issues, and agent responses. Always shown.
+	if (c.flow && c.flow.length) {
+	  const flowField = makeField("Flow", false, false);
+	  const ul = document.createElement("ul");
+	  ul.className = "flow";
+	  let issueIndex = 0;
+	  c.flow.forEach(entry => {
+		if (entry.outcome === "issue") issueIndex++;
+		ul.appendChild(renderFlowEntry(entry, issueIndex));
+	  });
+	  flowField.body.appendChild(ul);
+	  cbody.appendChild(flowField.field);
+	}
+
+	// Happy-path note — shown only when no flow entry carried a defect.
+	const anyDefect = (c.flow || []).some(e => e && e.defect);
+	if (!anyDefect && c.happyPathNote) {
+	  const happy = document.createElement("div");
+	  happy.className = "happy";
+	  happy.innerHTML = fmt(c.happyPathNote);
+	  cbody.appendChild(happy);
+	}
+
+	// Achievable note — case crossed the fail threshold but still completed through the MCP.
+	if (c.achievable) {
+	  const achievable = document.createElement("div");
+	  achievable.className = "achievable";
+	  achievable.innerHTML = fmt(c.achievable);
+	  cbody.appendChild(achievable);
+	}
+
+	el.querySelector(".case-head").addEventListener("click", () => el.classList.toggle("collapsed"));
+	return el;
+}
+
+const container = document.getElementById("cases");
+cases.forEach(c => container.appendChild(renderCase(c)));
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Migrates the `mcp-eval` skill into the Headless team's Claude Code plugin. It previously lived in a liferay-portal working tree, which does not host this plugin, so it could not be merged there.

The skill drives the Liferay MCP through a list of user-supplied use cases, running each case in an isolated `general-purpose` sub-agent under a hard MCP-only constraint, then renders the per-case verdicts (OK / PARTIAL / FAIL), roadblocks, and concrete fixes into a self-contained HTML report.

Files:
- `skills/mcp-eval/SKILL.md` — orchestrator + sub-agent prompt template.
- `skills/mcp-eval/report-template.html` — self-contained report template (`__CASE_DATA__` placeholder).