### PR TITLE
Add seed-objects skill for seeding demo Objects datasets

### DIFF
--- a/rules/object-admin-rest-api.md
+++ b/rules/object-admin-rest-api.md
@@ -1,0 +1,128 @@
+# Object Admin REST API
+
+Use these procedures whenever a skill creates, reads, or deletes Liferay Objects (object definitions, relationships, or entries) through the Headless REST API. Every interaction is a `curl` call against a running Liferay instance.
+
+## Target Instance and Authentication
+
+Default to a local bundle at `http://localhost:8080` authenticated as the default admin with HTTP basic auth `test@liferay.com:test`.
+
+```bash
+BASE="http://localhost:8080"
+AUTH="test@liferay.com:test"
+ADMIN="${BASE}/o/object-admin/v1.0"
+```
+
+Confirm the instance answers before doing any work:
+
+```bash
+curl --silent --output /dev/null --write-out "%{http_code}" \
+	--user "${AUTH}" "${ADMIN}/object-definitions?pageSize=1"
+```
+
+A `200` means ready. When the probe fails, the portal is either down or on another port: resolve the HTTP port from the running Tomcat's `conf/server.xml` (the `port` on the `protocol="HTTP/1.1"` connector — see the portal's `tomcat.md` rule), or accept a `--url` override from the caller. Never hardcode a non-8080 port.
+
+## Object Definitions
+
+Create a definition (it starts as a draft, `active: false`). `name` is alphanumeric, starts with an uppercase letter, and carries no spaces; Liferay prefixes the storage table with `C_`. `scope` is `company` or `site`. At least one `objectField` is required.
+
+```bash
+curl --silent --request POST --user "${AUTH}" \
+	--header "Content-Type: application/json" \
+	--url "${ADMIN}/object-definitions" \
+	--data '{
+		"label": {"en_US": "My Object"},
+		"pluralLabel": {"en_US": "My Objects"},
+		"name": "MyObject",
+		"scope": "company",
+		"objectFields": [
+			{
+				"label": {"en_US": "Title"},
+				"name": "title",
+				"businessType": "Text",
+				"type": "String"
+			}
+		]
+	}'
+```
+
+Set `panelCategoryKey` to `"control_panel.object"` (accepted on create or `PATCH`) so the definition's entries application is reachable from the UI under **Control Panel → Objects**; without it the entries are only visible through this REST API.
+
+The response carries the `id`, the `externalReferenceCode`, and an `actions` block whose `publish` href is the publish endpoint. Entries cannot be created until the definition is published:
+
+```bash
+curl --silent --request POST --user "${AUTH}" \
+	--url "${ADMIN}/object-definitions/${OBJECT_DEFINITION_ID}/publish"
+```
+
+Read a definition to recover its `restContextPath` (the entry endpoint, e.g. `/o/c/myobjects`) and its `rootObjectDefinitionExternalReferenceCode`:
+
+```bash
+curl --silent --user "${AUTH}" \
+	--url "${ADMIN}/object-definitions/${OBJECT_DEFINITION_ID}"
+```
+
+## Inheritance (Parent/Child Binding)
+
+Liferay has no field-level inheritance between object definitions. The parent/child structure the UI labels **inheritance** is an object **relationship** with `edge: true`, created on the parent. Binding sets the child's read-only `rootObjectDefinitionExternalReferenceCode` to the parent's `externalReferenceCode`, marking the child as part of the parent's tree. Create the edge **before** publishing the child.
+
+```bash
+curl --silent --request POST --user "${AUTH}" \
+	--header "Content-Type: application/json" \
+	--url "${ADMIN}/object-definitions/${PARENT_ID}/object-relationships" \
+	--data '{
+		"objectDefinitionId1": '"${PARENT_ID}"',
+		"objectDefinitionId2": '"${CHILD_ID}"',
+		"name": "myChildren",
+		"label": {"en_US": "My Children"},
+		"type": "oneToMany",
+		"deletionType": "cascade",
+		"edge": true
+	}'
+```
+
+`edge: true` (a bound tree) and entry-to-entry foreign keys are mutually exclusive through the entry API: a bound child's entries are independent of any parent entry, so do not attempt to set a relationship foreign key on a bound child's entries. Use `edge: false` only when the goal is a plain relationship whose child entries reference a parent entry by foreign key.
+
+## Plain Relationships and Entry Linking
+
+A plain relationship (`edge: false`) links entries by their type:
+
+- **`oneToMany`** creates a foreign-key object field on the **many** side (the child definition), named `r_<relationshipName>_c_<parentName>Id`. Discover it by reading the child definition and taking the `objectField` whose `businessType` is `Relationship` and whose name contains the relationship name. Link a child entry to a parent entry by setting that field to the parent entry's `id` in the child entry's body.
+
+- **`manyToMany`** creates **no** object field on either side; it is a join. Link two existing entries through the nested endpoint exposed under the relationship name, taking the relationship name as the path segment:
+
+	```bash
+	curl --silent --request PUT --user "${AUTH}" \
+		--url "${BASE}${LEFT_REST_CONTEXT_PATH}/${LEFT_ENTRY_ID}/${RELATIONSHIP_NAME}/${RIGHT_ENTRY_ID}"
+	```
+
+	`GET ${BASE}${LEFT_REST_CONTEXT_PATH}/${LEFT_ENTRY_ID}/${RELATIONSHIP_NAME}` lists the related entries. A plain relationship deletes directly (`DELETE ${ADMIN}/object-relationships/${RELATIONSHIP_ID}`), without the disable-inheritance step.
+
+## Object Entries
+
+Entries are created against the definition's `restContextPath`. Object field values are flat top-level keys (not nested under `properties`). Required fields must be present.
+
+```bash
+curl --silent --request POST --user "${AUTH}" \
+	--header "Content-Type: application/json" \
+	--url "${BASE}${REST_CONTEXT_PATH}" \
+	--data '{"title": "First entry"}'
+```
+
+List or count entries with a `GET` on the same path; `totalCount` reports the size.
+
+## Deletion (Cleanup)
+
+A definition bound by inheritance refuses deletion with *"you must first disable inheritance and delete its relationships."* Disabling inheritance is a **`PUT`** on the relationship with `edge: false` (a `PATCH` returns `405`); the relationship can then be deleted, and finally the definitions (children before the parent).
+
+```bash
+curl --silent --request PUT --user "${AUTH}" \
+	--header "Content-Type: application/json" \
+	--url "${ADMIN}/object-relationships/${RELATIONSHIP_ID}" \
+	--data '{"deletionType": "cascade", "edge": false, "label": {"en_US": "x"}, "name": "x", "type": "oneToMany"}'
+
+curl --silent --request DELETE --user "${AUTH}" \
+	--url "${ADMIN}/object-relationships/${RELATIONSHIP_ID}"
+
+curl --silent --request DELETE --user "${AUTH}" \
+	--url "${ADMIN}/object-definitions/${CHILD_ID}"
+```

--- a/skills/seed-objects/SKILL.md
+++ b/skills/seed-objects/SKILL.md
@@ -1,0 +1,81 @@
+---
+
+allowed-tools: Bash(curl *), Bash(python3 *), Bash(date *), Bash(grep *), Read, Grep
+argument-hint: "[--universities N] [--students N] [--subjects N] [--entries N] [--scope company|site] [--url http://host:port]"
+description: Seed a demo Objects dataset through the Headless REST API — a relational University / Student / Subject model plus a root-object (inheritance) Building tree — with their relationships and linked sample entries. Use when asked for an objects demo dataset, related objects, a root object / object tree, or data to test import/export or headless.
+name: seed-objects
+
+---
+
+# Seed Objects
+
+Build a demo Objects dataset on a running Liferay instance, covering both relationship styles in one pass:
+
+- **Relational cluster** (plain relationships, `edge: false`) — **University**, **Student**, **Subject** with foreign-key and many-to-many links between entries.
+- **Root-object cluster** (inheritance, `edge: true`) — a **Building** root object with **Classroom** and **Laboratory** children bound to it, each with its own entries.
+
+All calls go through `../../rules/object-admin-rest-api.md`.
+
+```
+Relational (edge:false)            Root object / inheritance (edge:true)
+University 1 ──< Student            Building (root)
+University 1 ──< Subject            ├── Classroom   (bound)
+Student   M >──< Subject            └── Laboratory  (bound)
+```
+
+## Input
+
+Resolve from `${ARGUMENTS}`, falling back to the defaults:
+
+- **`--universities N`** — universities to seed. Defaults to `2` (e.g. MIT, Stanford).
+- **`--students N`** — students per university. Defaults to `3`.
+- **`--subjects N`** — subjects per university. Defaults to `3`.
+- **`--entries N`** — entries per root-object definition (Building, Classroom, Laboratory). Defaults to `2`.
+- **`--scope`** — `company` or `site`. Defaults to `company`.
+- **`--url`** — base URL of the target instance. Defaults to `http://localhost:8080`.
+
+Definition names carry a timestamp suffix (e.g. `University143052`) so repeated runs do not collide; report the labels, which stay clean. Every definition is created with `panelCategoryKey: "control_panel.object"` so it appears in the UI under **Control Panel → Objects**.
+
+## Procedure
+
+Run the whole sequence without pausing for confirmation; it only creates data on a development instance.
+
+### 1. Confirm the Target
+
+Set `BASE` from `--url`, `AUTH="test@liferay.com:test"`, `ADMIN="${BASE}/o/object-admin/v1.0"`, and probe per the rule. Abort with a clear message when the probe is not `200`.
+
+### 2. Create the Definitions (Draft)
+
+Create all definitions with `POST ${ADMIN}/object-definitions`, each with `Text`/`String` fields and `panelCategoryKey: "control_panel.object"`:
+
+- Relational — **University** (`name` required, `location`), **Student** (`name` required, `email`), **Subject** (`name` required, `code`).
+- Root object — **Building** (`name` required, `address`), **Classroom** (`name` required, `seats`), **Laboratory** (`name` required, `equipment`).
+
+Capture each `id`, and Building's `externalReferenceCode`.
+
+### 3. Wire the Relationships
+
+Create on the parent/`objectDefinitionId1` side, **before publishing**:
+
+- Relational, `edge: false`: `oneToMany` University → Student (`students`); `oneToMany` University → Subject (`subjects`); `manyToMany` Student → Subject (`enrolledSubjects`).
+- Inheritance, `edge: true`: `oneToMany` Building → Classroom (`classrooms`); `oneToMany` Building → Laboratory (`laboratories`). Binding sets each child's `rootObjectDefinitionExternalReferenceCode` to Building's `externalReferenceCode`.
+
+### 4. Publish
+
+`POST ${ADMIN}/object-definitions/${ID}/publish` for all six definitions.
+
+### 5. Seed and Link Entries
+
+Read each definition's `restContextPath`, then:
+
+1. **Relational** — create `--universities` University entries. For each university, create `--students` Student and `--subjects` Subject entries, setting each one's University foreign-key field (discover it per the rule: the `Relationship` object field whose name contains the relationship name) to that university's entry `id`. Then enroll each student in a couple of that university's subjects through the `manyToMany` nested endpoint `PUT ${BASE}${STUDENT_REST_CONTEXT_PATH}/${STUDENT_ID}/enrolledSubjects/${SUBJECT_ID}`, varying the pairings.
+2. **Root object** — create `--entries` entries in each of Building, Classroom, and Laboratory. A bound child's entries are independent of the root's entries — do not link them by foreign key.
+
+### 6. Verify and Report
+
+Confirm a sample student's University foreign key resolves and that `GET .../${STUDENT_ID}/enrolledSubjects` returns the expected subjects; confirm Classroom's and Laboratory's `rootObjectDefinitionExternalReferenceCode` equals Building's `externalReferenceCode`. Report two tables (relational, root object) of definitions with `id`, label, and `restContextPath`, the entry counts per definition, a few example enrollments, and the admin UI link (`${BASE}/group/control_panel/manage?p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet`).
+
+## Notes
+
+- The two clusters are independent: the relational one demonstrates entry-level links (`oneToMany` foreign key set in the child entry's body; `manyToMany` through the nested `PUT` named after the relationship), while the root-object one demonstrates definition-level inheritance (`edge: true`), where children are bound to the root but their entries stand alone.
+- To remove the dataset afterwards, follow the rule's cleanup order: for every relationship `PUT` it with `edge: false` (this also disables inheritance on the `edge: true` ones), `DELETE` the relationships, then `DELETE` the children before their parent/root.


### PR DESCRIPTION
### What is being changed?

Adds a `seed-objects` skill and a shared `object-admin-rest-api` rule. The skill seeds a demo Objects dataset on a running Liferay instance through the Headless REST API: a relational University / Student / Subject model (oneToMany + manyToMany, entries linked by foreign key and many-to-many) plus a root-object Building tree whose Classroom and Laboratory children are bound through inheritance. Every definition is created under the Control Panel → Objects panel category. The rule centralizes the Object Admin REST endpoints, payload shapes, the inheritance vs plain-relationship distinction, entry linking, and the cleanup order.

### Why is it being changed?

Spinning up related object definitions with sample data — including root-object/inheritance trees — is a recurring need for testing import/export, headless, and demos, and doing it by hand against the REST API is slow and easy to get wrong.

### How can we test the changes?

Install the plugin from a local clone (`claude plugin marketplace add ./` then `claude plugin install liferay-headless@liferay-headless`) and restart Claude Code. With a local bundle running on `http://localhost:8080`, invoke `/seed-objects`. Confirm the six definitions appear under Control Panel → Objects, that a student's University foreign key resolves and the student's `enrolledSubjects` lists subjects, and that Classroom/Laboratory carry Building's `rootObjectDefinitionExternalReferenceCode`. The skill's procedure was verified end-to-end against a live instance.
